### PR TITLE
AUTO-714 fix status update return bug

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -335,6 +335,11 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
+  if (response.empty()) {
+    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+    return false;
+  }
+
   RCLCPP_DEBUG(logger_, "Full response: %s", response.c_str());
 
   // Strip STX and ETX before calculating the CRC.
@@ -421,6 +426,11 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
 
   // Get the response
   std::string response = sendCommand(str_cmd);
+
+  if (response.empty()) {
+    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+    return false;
+  }
 
   RCLCPP_DEBUG(logger_, "Full response: %s", response.c_str());
 


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-714).

This PR fixes an unhandled exception when reading the sensor status under bad network conditions. 

std::string URGCWrapper::sendCommand(std::string cmd)

Returns an empty string response when an error occurs, none of the callers are checking if this response is empty and bad things ensue. This PR adds a response empty check.