### PR TITLE
AUTO-715 Fix driver hanging due to signed unsigned return conversion

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -567,11 +567,11 @@ std::string URGCWrapper::sendCommand(std::string cmd)
 
   // All serial command structures start with STX + LEN as
   // the first 5 bytes, read those in.
-  size_t total_read_len = 0;
-  size_t read_len = 0;
+  ssize_t total_read_len = 0;
+  ssize_t read_len = 0;
   // Read in the header, make sure we get all 5 bytes expcted
   char recvb[5] = {0};
-  size_t expected_read = 5;
+  ssize_t expected_read = 5;
   while (total_read_len < expected_read) {
     read_len = read(sock, recvb + total_read_len, expected_read - total_read_len);  // READ STX
     total_read_len += read_len;


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-715)

This PR fixes a bug in the sendCommand function, socket read returns a sstize_t which was being cast to an unsigned. So -1 was converted to 18446744073709551615 and then added to the total_read_len which wraps around to same value it had already (so the loop termination condition is never reached) and also fools the error if statement because it's greater than 0. 

Very sneaky!