### PR TITLE
AUTO-719 increased delay in diagnostics thread to slow down publish rate

### DIFF
--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -342,7 +342,7 @@ void UrgNode::updateDiagnostics()
 {
   while (!close_diagnostics_) {
     diagnostic_updater_.force_update();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
 }
 


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-719)

This PR reduces the diagnostics publish rate to a manageable rate, currently its updating at ~96Hz. This PR drops it down to 2. 