### PR TITLE
AUTO-721 added missing check for packet length

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -102,6 +102,9 @@ struct SerialConnection
   int serial_baud;
 };
 
+static const size_t AR00_PACKET_SIZE = 4379;
+static const size_t DL00_PACKET_SIZE = 1936;
+
 class URGCWrapper
 {
 public:

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -336,7 +336,8 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   std::string response = sendCommand(str_cmd);
 
   if (response.empty() || response.size() < AR00_PACKET_SIZE) {
-    RCLCPP_WARN(logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
+    RCLCPP_WARN(
+      logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
       AR00_PACKET_SIZE, response.size());
     return false;
   }
@@ -429,7 +430,8 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
   std::string response = sendCommand(str_cmd);
 
   if (response.empty() || response.size() < DL00_PACKET_SIZE) {
-    RCLCPP_WARN(logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
+    RCLCPP_WARN(
+      logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
       DL00_PACKET_SIZE, response.size());
     return false;
   }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -335,8 +335,9 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
-  if (response.empty()) {
-    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+  if (response.empty() || response.size() < AR00_PACKET_SIZE) {
+    RCLCPP_WARN(logger_, "Invalid response from AR00 expected size: %lu actual: %lu",
+      AR00_PACKET_SIZE, response.size());
     return false;
   }
 
@@ -427,8 +428,9 @@ bool URGCWrapper::getDL00Status(UrgDetectionReport & report)
   // Get the response
   std::string response = sendCommand(str_cmd);
 
-  if (response.empty()) {
-    RCLCPP_WARN(logger_, "Received empty response from AR00 command");
+  if (response.empty() || response.size() < DL00_PACKET_SIZE) {
+    RCLCPP_WARN(logger_, "Invalid response from DL00 expected size: %lu actual: %lu",
+      DL00_PACKET_SIZE, response.size());
     return false;
   }
 


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-721)

This PR adds length check for AR00 and DL00 packets without it the function could try to parse an invalid length packet and throw a std::length error when indexing into the string. I look the length values direct from the UAM protocol manual and verified them on the real sensor. 