### PR TITLE
AUTO-725 add explicit socket timeout and counting status failure as error

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -573,6 +573,11 @@ std::string URGCWrapper::sendCommand(std::string cmd)
 
   // Get the socket reference and send
   int sock = urg_.connection.tcpclient.sock_desc;
+
+  struct timeval tv;
+  tv.tv_sec = 1;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+
   write(sock, cmd.c_str(), cmd.size());
 
   // All serial command structures start with STX + LEN as

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -561,7 +561,8 @@ void UrgNode::scanThread()
       }
 
       if (this->now() - last_status_update > rclcpp::Duration::from_seconds(status_update_delay_)) {
-        this->updateStatus();
+        if (!this->updateStatus())
+          error_count_++;
         last_status_update = this->now();
       }
 


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-725)

The PR adds an explicit 1 second socket timeout to the status read. It gets set to different values over the in the underlying urg_connection/tcp_client library so it's worth setting to something that works for the status explicitly. 

Also the driver now counts a failure in the status update towards the error_count. 