### PR TITLE
AUTO-695 Improve status update performance

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -103,6 +103,7 @@ struct SerialConnection
 };
 
 static const size_t AR00_PACKET_SIZE = 4379;
+static const size_t XR00_PACKET_SIZE = 106;
 static const size_t DL00_PACKET_SIZE = 1936;
 
 class URGCWrapper
@@ -184,7 +185,7 @@ public:
 
   bool grabScan(sensor_msgs::msg::MultiEchoLaserScan & msg);
 
-  bool getAR00Status(URGStatus & status);
+  bool getXR00Status(URGStatus & status);
 
   bool getDL00Status(UrgDetectionReport & report);
 
@@ -221,7 +222,7 @@ private:
    * @param cmd The arbitrary command fully formatted to be sent as provided
    * @returns The textual response of the Lidar, empty if, but may return lidar's own error string.
    */
-  std::string sendCommand(std::string cmd);
+  std::string sendCommand(const std::string & cmd, bool stop_scan);
 
   std::string ip_address_;
   int ip_port_;

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -337,7 +337,7 @@ bool URGCWrapper::getXR00Status(URGStatus & status)
 
   if (response.empty() || response.size() < XR00_PACKET_SIZE) {
     RCLCPP_WARN(
-      logger_, "Invalid response from XR00 expected size: %lu actual: %lu", AR00_PACKET_SIZE,
+      logger_, "Invalid response from XR00 expected size: %lu actual: %lu", XR00_PACKET_SIZE,
       response.size());
     return false;
   }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -329,7 +329,7 @@ bool URGCWrapper::getXR00Status(URGStatus & status)
   // Construct and write AR00 command.
   std::string str_cmd;
   str_cmd += 0x02;                 // STX
-  str_cmd.append("000EXR009AD0");  // AR01 cmd with length and checksum.
+  str_cmd.append("000EXR009AD0");  // XR00 cmd with length and checksum.
   str_cmd += 0x03;                 // ETX
 
   // Get the response

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -326,7 +326,7 @@ bool URGCWrapper::grabScan(sensor_msgs::msg::MultiEchoLaserScan & msg)
 
 bool URGCWrapper::getXR00Status(URGStatus & status)
 {
-  // Construct and write AR00 command.
+  // Construct and write XR00 command.
   std::string str_cmd;
   str_cmd += 0x02;                 // STX
   str_cmd.append("000EXR009AD0");  // XR00 cmd with length and checksum.

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -416,8 +416,8 @@ bool URGCWrapper::getXR00Status(URGStatus & status)
 
   // Get the contamination status
   ss.clear();
-  ss << response.substr(42, 1);
-  RCLCPP_DEBUG(logger_, "Contamination: %s", response.substr(42, 1).c_str());
+  ss << response.substr(60, 1);
+  RCLCPP_DEBUG(logger_, "Contamination: %s", response.substr(60, 1).c_str());
   ss >> std::hex >> status.contamination_warning;
 
   return true;

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -154,10 +154,9 @@ bool UrgNode::updateStatus()
 
   if (urg_) {
     device_status_ = urg_->getSensorStatus();
-
     if (detailed_status_) {
       URGStatus status;
-      if (urg_->getAR00Status(status)) {
+      if (urg_->getXR00Status(status)) {
         urg_node_msgs::msg::Status msg;
         msg.operating_mode = status.operating_mode;
         msg.error_status = status.error_status;
@@ -184,6 +183,8 @@ bool UrgNode::updateStatus()
         urg_node_msgs::msg::Status msg;
         status_pub_->publish(msg);
       }
+    } else {
+      result = true;
     }
   }
   return result;


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-695)

This PR adapts the status update function in the urg_node to use the XR00 command instead of the AR00 command. The main difference between the two is XR00 does not retrieve the  scan data. This removes the previous requirement to stop the scan data streaming before reading the status command (which costs ~0.03 seconds).

This is a nice performance improvement for the status update which means we can update it more frequently than once every 30 seconds. 

