### PR TITLE
AUTO-751 Hokuyo Timeout Fix

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -42,10 +42,8 @@
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
-
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "sensor_msgs/msg/multi_echo_laser_scan.hpp"
-
 #include "urg_c/urg_sensor.h"
 #include "urg_c/urg_utils.h"
 
@@ -112,13 +110,11 @@ class URGCWrapper
 {
 public:
   URGCWrapper(
-    const EthernetConnection & connection,
-    bool & using_intensity, bool & using_multiecho,
+    const EthernetConnection & connection, bool & using_intensity, bool & using_multiecho,
     const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"));
 
   URGCWrapper(
-    const SerialConnection & connection,
-    bool & using_intensity, bool & using_multiecho,
+    const SerialConnection & connection, bool & using_intensity, bool & using_multiecho,
     const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"));
 
   ~URGCWrapper();
@@ -227,8 +223,7 @@ private:
    * @returns The textual response of the Lidar, empty if, but may return lidar's own error string.
    */
   std::string sendCommand(
-    const std::string & cmd, bool stop_scan,
-    const ssize_t & expected_packet_length);
+    const std::string & cmd, bool stop_scan, const ssize_t & expected_packet_length);
 
   std::string ip_address_;
   int ip_port_;
@@ -243,7 +238,7 @@ private:
   // TODO(karsten1987): Verify the real data type of this
   // cppcheck complains that `long` isn't type safe.
   // ignoring this check for now given that this requires changes in urg_c as well.
-  std::vector<long> data_;  // NOLINT
+  std::vector<long> data_;                 // NOLINT
   std::vector<unsigned short> intensity_;  // NOLINT
 
   bool use_intensity_;

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -226,7 +226,7 @@ private:
    * @param cmd The arbitrary command fully formatted to be sent as provided
    * @returns The textual response of the Lidar, empty if, but may return lidar's own error string.
    */
-  std::string sendCommand(const std::string & cmd, bool stop_scan);
+  std::string sendCommand(const std::string & cmd, bool stop_scan, const ssize_t &expected_packet_length);
 
   std::string ip_address_;
   int ip_port_;

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -226,7 +226,9 @@ private:
    * @param cmd The arbitrary command fully formatted to be sent as provided
    * @returns The textual response of the Lidar, empty if, but may return lidar's own error string.
    */
-  std::string sendCommand(const std::string & cmd, bool stop_scan, const ssize_t &expected_packet_length);
+  std::string sendCommand(
+    const std::string & cmd, bool stop_scan,
+    const ssize_t & expected_packet_length);
 
   std::string ip_address_;
   int ip_port_;

--- a/include/urg_node/urg_node.hpp
+++ b/include/urg_node/urg_node.hpp
@@ -35,28 +35,23 @@
 #ifndef URG_NODE__URG_NODE_HPP_
 #define URG_NODE__URG_NODE_HPP_
 
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
-#include <atomic>
 
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "diagnostic_updater/publisher.hpp"
-#include "diagnostic_msgs/msg/diagnostic_status.hpp"
-
 #include "laser_proc/laser_publisher.hpp"
-
 #include "rcl_interfaces/msg/parameter.hpp"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
-
 #include "rclcpp/rclcpp.hpp"
-
 #include "std_srvs/srv/trigger.hpp"
-
-#include "urg_node_msgs/msg/status.hpp"
 #include "urg_node/urg_c_wrapper.hpp"
+#include "urg_node_msgs/msg/status.hpp"
 
 namespace urg_node
 {

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -205,8 +205,15 @@ void URGCWrapper::stop()
 
 URGCWrapper::~URGCWrapper()
 {
-  stop();
-  urg_close(&urg_);
+  // TODO(richardw347): This is a bit exterme to always ensure the
+  // socket is closed on destruction. However this is necessary
+  // at the moment to ensure the sensor can alawys be restarted
+  // stop();
+  // urg_close(&urg_);
+  int sock = urg_.connection.tcpclient.sock_desc;
+  if (sock != -1) {
+    close(sock);
+  }
 }
 
 bool URGCWrapper::grabScan(sensor_msgs::msg::LaserScan & msg)

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -210,6 +210,7 @@ URGCWrapper::~URGCWrapper()
   // at the moment to ensure the sensor can alawys be restarted
   // stop();
   // urg_close(&urg_);
+  RCLCPP_INFO(logger_, "URGCWrapper destructor called, closing socket");
   int sock = urg_.connection.tcpclient.sock_desc;
   if (sock != -1) {
     close(sock);

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -573,7 +573,7 @@ void UrgNode::scanThread()
 
       if (this->now() - last_status_update > rclcpp::Duration::from_seconds(status_update_delay_)) {
         if (!this->updateStatus()) {
-          error_count_++;
+          error_count_ = error_limit_ + 1;
         }
         last_status_update = this->now();
       }


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-751)

I've tracked this issue some to some **extreme** CPU stress, when the CPU is under massive load occasionally the status command will fail. The problem with the urg_node though is once it fails under these circumstances it is not able to recover.  What I've done to address this is:

First I've simplified the sendCommand function which is used to read the status update. Previously it would:

1. send the command, 
2. read the response header, 
3. parse it to get the packet length 
4. read the rest of the message. 

Reading the header is unnecessary because the packet length isn't dynamic it's always 106 bytes and quite often the function fails at step 2/3 and leaves the socket in a bad state. I've refactored it to:

1. send the command
2. read the response 

This ensures when it fails the socket is in a cleaner state. 

I've also added two additional points to improve recovery:

- If the status command fails, the node will immediately try to reconnect instead of just incrementing the error count.
- If the socket is ever in a bad state, if we try to reconnect, stopping the sensor and cleanly closing the socket connection can sometimes fails. I've changed this to the most reliable, a direct call to close(socket_fd).

### Testing

Warning testing this is a bit tricky and if not done correctly can result in a locked up robot.

1. Star the full stack `ros2 launch arri_bringup full.launch.py`
2. Once the robot is in another terminal run `stress -c 500`
3. This will massively overload the CPU
4. Things will start to fail but after a few seconds it goes completely crazy with lots of monitor failures, TF failures, nav2 failures. 
5. In the middle of this the urg_node will report the status update has failed
6. If you stop the stress command when this has happened most of the robot will recover except the urg_node 
7. You should see the telltale monitor failure:
```
WAR [report.hpp:32 notOkMonitorsToLog()]  OK(false) HokuyoFrontLeftLidarMonitorMsg: No message received within 1.00 seconds limit, it's been 29.00 seconds since the last message was received
WAR [report.hpp:32 notOkMonitorsToLog()]  OK(false) HokuyoBackRightLidarMonitorMsg: No message received within 1.00 seconds limit, it's been 758.59 seconds since the last message was received'
```

Running the same test with this PR the urg_node will still fail, but it will disconnect and reconnect to recover.