### PR TITLE
AUTO-912 Add SO_LINGER disable parameter

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -199,6 +199,8 @@ public:
 
   bool getDL00Status(UrgDetectionReport & report);
 
+  void setSocketOptions();
+
 private:
   void initialize(bool & using_intensity, bool & using_multiecho);
 
@@ -269,6 +271,10 @@ private:
 
   /// Logger object used for debug info
   rclcpp::Logger logger_;
+
+  bool disable_linger_;
+  bool tcp_nodelay_;
+  std::string tcp_congestion_control_;
 };
 }  // namespace urg_node
 

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -118,9 +118,7 @@ public:
     const EthernetConnection & connection,
     bool & using_intensity, bool & using_multiecho,
     const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"),
-    bool disable_linger = false,
-    bool tcp_nodelay = false,
-    const std::string& tcp_congestion_control = std::string(""));
+    bool disable_linger = false);
 
   URGCWrapper(
     const SerialConnection & connection,
@@ -198,8 +196,6 @@ public:
   bool getXR00Status(URGStatus & status);
 
   bool getDL00Status(UrgDetectionReport & report);
-
-  void setSocketOptions();
 
 private:
   void initialize(bool & using_intensity, bool & using_multiecho);

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -118,6 +118,7 @@ public:
     const EthernetConnection & connection,
     bool & using_intensity, bool & using_multiecho,
     const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"),
+    bool disable_linger = false,
     bool tcp_nodelay = false,
     const std::string& tcp_congestion_control = std::string(""));
 

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -34,12 +34,15 @@
 #ifndef URG_NODE__URG_C_WRAPPER_HPP_
 #define URG_NODE__URG_C_WRAPPER_HPP_
 
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <chrono>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -49,8 +52,7 @@
 #include "urg_c/urg_sensor.h"
 #include "urg_c/urg_utils.h"
 
-#include <netinet/in.h>
-#include <netinet/tcp.h>
+
 
 namespace urg_node
 {
@@ -268,7 +270,6 @@ private:
   /// Logger object used for debug info
   rclcpp::Logger logger_;
   bool disable_linger_;
-
 };
 }  // namespace urg_node
 

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -271,10 +271,8 @@ private:
 
   /// Logger object used for debug info
   rclcpp::Logger logger_;
-
   bool disable_linger_;
-  bool tcp_nodelay_;
-  std::string tcp_congestion_control_;
+
 };
 }  // namespace urg_node
 

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -53,7 +53,6 @@
 #include "urg_c/urg_utils.h"
 
 
-
 namespace urg_node
 {
 

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -117,7 +117,9 @@ public:
   URGCWrapper(
     const EthernetConnection & connection,
     bool & using_intensity, bool & using_multiecho,
-    const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"));
+    const rclcpp::Logger & logger = rclcpp::get_logger("urg_c_wrapper"),
+    bool tcp_nodelay = false,
+    const std::string& tcp_congestion_control = std::string(""));
 
   URGCWrapper(
     const SerialConnection & connection,

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -49,6 +49,9 @@
 #include "urg_c/urg_sensor.h"
 #include "urg_c/urg_utils.h"
 
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
 namespace urg_node
 {
 

--- a/include/urg_node/urg_node.hpp
+++ b/include/urg_node/urg_node.hpp
@@ -169,6 +169,9 @@ private:
   /** how long to wait to reconnect **/
   double reconn_delay_;
 
+  bool tcp_nodelay_;
+  std::string tcp_congestion_control_;
+
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_pub_;
   std::unique_ptr<laser_proc::LaserPublisher> echoes_pub_;
   rclcpp::Publisher<urg_node_msgs::msg::Status>::SharedPtr status_pub_;

--- a/include/urg_node/urg_node.hpp
+++ b/include/urg_node/urg_node.hpp
@@ -169,6 +169,7 @@ private:
   /** how long to wait to reconnect **/
   double reconn_delay_;
 
+  bool disable_linger_;
   bool tcp_nodelay_;
   std::string tcp_congestion_control_;
 

--- a/include/urg_node/urg_node.hpp
+++ b/include/urg_node/urg_node.hpp
@@ -170,8 +170,6 @@ private:
   double reconn_delay_;
 
   bool disable_linger_;
-  bool tcp_nodelay_;
-  std::string tcp_congestion_control_;
 
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_pub_;
   std::unique_ptr<laser_proc::LaserPublisher> echoes_pub_;

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -48,9 +48,7 @@ namespace urg_node
 URGCWrapper::URGCWrapper(
   const EthernetConnection & connection, bool & using_intensity,
   bool & using_multiecho, const rclcpp::Logger & logger,
-  bool disable_linger,
-  bool tcp_nodelay,
-  const std::string& tcp_congestion_control)
+  bool disable_linger)
   : ip_address_(connection.ip_address),
   ip_port_(connection.ip_port),
   serial_port_(""),
@@ -78,7 +76,6 @@ URGCWrapper::URGCWrapper(
 
   initialize(using_intensity, using_multiecho);
 
-  setSocketOptions();
 }
 
 URGCWrapper::URGCWrapper(

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -72,6 +72,14 @@ URGCWrapper::URGCWrapper(
     throw std::runtime_error(ss.str());
   }
 
+  // Set TCP_NODELAY
+    int flag = 1;
+    int sock = urg_.connection.tcpclient.sock_desc;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) {
+        RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
+    }
+
+
   initialize(using_intensity, using_multiecho);
 }
 

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -80,7 +80,7 @@ URGCWrapper::URGCWrapper(
   if (tcp_nodelay)
   {
     int flag = 1;
-    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) 
+    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1)
     {
         RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
     }
@@ -96,7 +96,7 @@ URGCWrapper::URGCWrapper(
   }
   else
   {
-    if (setsockopt(sock, IPPROTO_TCP, TCP_CONGESTION, tcp_congestion_control.c_str(), tcp_congestion_control.length() == -1)) 
+    if (setsockopt(sock, IPPROTO_TCP, TCP_CONGESTION, tcp_congestion_control.c_str(), tcp_congestion_control.length()) == -1)
     {
         RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
     }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -49,7 +49,7 @@ URGCWrapper::URGCWrapper(
   const EthernetConnection & connection, bool & using_intensity,
   bool & using_multiecho, const rclcpp::Logger & logger,
   bool disable_linger)
-  : ip_address_(connection.ip_address),
+: ip_address_(connection.ip_address),
   ip_port_(connection.ip_port),
   serial_port_(""),
   serial_baud_(0),
@@ -209,17 +209,18 @@ void URGCWrapper::stop()
 URGCWrapper::~URGCWrapper()
 {
   // stop();
-  if (disable_linger_)
-  {
+  if (disable_linger_) {
     // Disable SO_LINGER option
     struct linger linger_opt;
     linger_opt.l_onoff = 1;  // Disable SO_LINGER
     linger_opt.l_linger = 0;  // Not used when l_onoff is 0
 
-    if (setsockopt(urg_.connection.tcpclient.sock_desc, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)) == -1) {
-        RCLCPP_ERROR(logger_, "Could not set SO_LINGER off on socket: %s", strerror(errno));
-    }
-    else {
+    if (setsockopt(
+        urg_.connection.tcpclient.sock_desc, SOL_SOCKET, SO_LINGER, &linger_opt,
+        sizeof(linger_opt)) == -1)
+    {
+      RCLCPP_ERROR(logger_, "Could not set SO_LINGER off on socket: %s", strerror(errno));
+    } else {
       RCLCPP_INFO(logger_, "Disabled SO_LINGER");
     }
   }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -259,7 +259,7 @@ void URGCWrapper::setSocketOptions()
   }
   else
   {
-    if (setsockopt(sock, IPPROTO_TCP, TCP_CONGESTION, tcp_congestion_control.c_str(), tcp_congestion_control.length()) == -1)
+    if (setsockopt(sock, IPPROTO_TCP, TCP_CONGESTION, tcp_congestion_control_.c_str(), tcp_congestion_control_.length()) == -1)
     {
         RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
     }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -265,7 +265,7 @@ void URGCWrapper::setSocketOptions()
     }
     else
     {
-        RCLCPP_INFO(logger_, "Set TCP_CONGESTION to %s", tcp_congestion_control.c_str());
+        RCLCPP_INFO(logger_, "Set TCP_CONGESTION to %s", tcp_congestion_control_.c_str());
     }
   }
 }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -61,8 +61,6 @@ URGCWrapper::URGCWrapper(
   user_latency_(std::chrono::seconds(0)),
   logger_(logger),
   disable_linger_(disable_linger),
-  tcp_nodelay_(tcp_nodelay),
-  tcp_congestion_control_(tcp_congestion_control)
 {
   (void) adj_alpha_;
 
@@ -230,41 +228,6 @@ URGCWrapper::~URGCWrapper()
   }
   //urg_close(&urg_);
   close(urg_.connection.tcpclient.sock_desc);
-}
-
-void URGCWrapper::setSocketOptions()
-{
-
-  // Set TCP_NODELAY
-  if (tcp_nodelay_)
-  {
-    int flag = 1;
-    if (setsockopt(urg_.connection.tcpclient.sock_desc, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) {
-        RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
-    }
-    else {
-      RCLCPP_INFO(logger_, "Set TCP_NODELAY");
-    }
-  }
-  else {
-     RCLCPP_INFO(logger_, "Not setting TCP_NODELAY");
-  }
-
-  if (tcp_congestion_control_.empty())
-  {
-    RCLCPP_INFO(logger_, "Not setting TCP_CONGESTION");
-  }
-  else {
-    char buf[256];
-    strcpy(buf, tcp_congestion_control_.c_str());
-    socklen_t len = strlen(buf);
-    if (setsockopt(urg_.connection.tcpclient.sock_desc, IPPROTO_TCP, TCP_CONGESTION, buf, len) == -1) {
-      RCLCPP_ERROR(logger_, "Could not set socket congestion to %s on socket: %s", tcp_congestion_control_.c_str(), strerror(errno));
-    }
-    else {
-      RCLCPP_INFO(logger_, "Set TCP_CONGESTION to %s", tcp_congestion_control_.c_str());
-    }
-  }
 }
 
 bool URGCWrapper::grabScan(sensor_msgs::msg::LaserScan & msg)

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -213,59 +213,56 @@ void URGCWrapper::stop()
 
 URGCWrapper::~URGCWrapper()
 {
-  stop();
-  urg_close(&urg_);
-}
-
-void URGCWrapper::setSocketOptions()
-{
-  int sock = urg_.connection.tcpclient.sock_desc;
-
+  // stop();
   if (disable_linger_)
   {
     // Disable SO_LINGER option
     struct linger linger_opt;
-    linger_opt.l_onoff = 0;  // Disable SO_LINGER
+    linger_opt.l_onoff = 1;  // Disable SO_LINGER
     linger_opt.l_linger = 0;  // Not used when l_onoff is 0
 
-    if (setsockopt(sock, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)) == -1)
-    {
+    if (setsockopt(urg_.connection.tcpclient.sock_desc, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)) == -1) {
         RCLCPP_ERROR(logger_, "Could not set SO_LINGER off on socket: %s", strerror(errno));
     }
-    else
-    {
+    else {
       RCLCPP_INFO(logger_, "Disabled SO_LINGER");
     }
   }
+  //urg_close(&urg_);
+  close(urg_.connection.tcpclient.sock_desc);
+}
 
+void URGCWrapper::setSocketOptions()
+{
 
   // Set TCP_NODELAY
   if (tcp_nodelay_)
   {
     int flag = 1;
-    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1)
-    {
+    if (setsockopt(urg_.connection.tcpclient.sock_desc, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag)) == -1) {
         RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
     }
-    else
-    {
+    else {
       RCLCPP_INFO(logger_, "Set TCP_NODELAY");
     }
+  }
+  else {
+     RCLCPP_INFO(logger_, "Not setting TCP_NODELAY");
   }
 
   if (tcp_congestion_control_.empty())
   {
-      RCLCPP_INFO(logger_, "Not setting TCP_CONGESTION");
+    RCLCPP_INFO(logger_, "Not setting TCP_CONGESTION");
   }
-  else
-  {
-    if (setsockopt(sock, IPPROTO_TCP, TCP_CONGESTION, tcp_congestion_control_.c_str(), tcp_congestion_control_.length()) == -1)
-    {
-        RCLCPP_ERROR(logger_, "Could not set TCP_NODELAY on socket: %s", strerror(errno));
+  else {
+    char buf[256];
+    strcpy(buf, tcp_congestion_control_.c_str());
+    socklen_t len = strlen(buf);
+    if (setsockopt(urg_.connection.tcpclient.sock_desc, IPPROTO_TCP, TCP_CONGESTION, buf, len) == -1) {
+      RCLCPP_ERROR(logger_, "Could not set socket congestion to %s on socket: %s", tcp_congestion_control_.c_str(), strerror(errno));
     }
-    else
-    {
-        RCLCPP_INFO(logger_, "Set TCP_CONGESTION to %s", tcp_congestion_control_.c_str());
+    else {
+      RCLCPP_INFO(logger_, "Set TCP_CONGESTION to %s", tcp_congestion_control_.c_str());
     }
   }
 }

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -79,6 +79,8 @@ URGCWrapper::URGCWrapper(
   }
 
   initialize(using_intensity, using_multiecho);
+
+  setSocketOptions();
 }
 
 URGCWrapper::URGCWrapper(
@@ -111,8 +113,6 @@ URGCWrapper::URGCWrapper(
   }
 
   initialize(using_intensity, using_multiecho);
-
-  setSocketOptions();
 }
 
 void URGCWrapper::initialize(bool & using_intensity, bool & using_multiecho)

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -75,7 +75,6 @@ URGCWrapper::URGCWrapper(
   }
 
   initialize(using_intensity, using_multiecho);
-
 }
 
 URGCWrapper::URGCWrapper(
@@ -224,7 +223,7 @@ URGCWrapper::~URGCWrapper()
       RCLCPP_INFO(logger_, "Disabled SO_LINGER");
     }
   }
-  //urg_close(&urg_);
+  // urg_close(&urg_);
   close(urg_.connection.tcpclient.sock_desc);
 }
 

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -58,7 +58,7 @@ URGCWrapper::URGCWrapper(
   system_latency_(std::chrono::seconds(0)),
   user_latency_(std::chrono::seconds(0)),
   logger_(logger),
-  disable_linger_(disable_linger),
+  disable_linger_(disable_linger)
 {
   (void) adj_alpha_;
 

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -74,6 +74,7 @@ UrgNode::UrgNode(const rclcpp::NodeOptions & node_options)
   service_yield_(true),
   status_update_delay_(10.0),
   reconn_delay_(0.5),
+  disable_linger_(false),
   tcp_nodelay_(false),
   tcp_congestion_control_("")
 {
@@ -109,6 +110,7 @@ void UrgNode::initSetup()
   cluster_ = this->declare_parameter<int>("cluster", cluster_);
   status_update_delay_ = declare_parameter<double>("status_update_delay", status_update_delay_);
   reconn_delay_ = declare_parameter<double>("reconnect_delay", reconn_delay_);
+  disable_linger_ = declare_parameter<bool>("disable_linger", disable_linger_);
   tcp_nodelay_ = declare_parameter<bool>("tcp_nodelay", tcp_nodelay_);
   tcp_congestion_control_ = declare_parameter<std::string>("tcp_congestion_control", tcp_congestion_control_);
 
@@ -433,7 +435,8 @@ bool UrgNode::connect()
       urg_.reset(
         new urg_node::URGCWrapper(
           connection,
-          publish_intensity_, publish_multiecho_, this->get_logger()));
+          publish_intensity_, publish_multiecho_, this->get_logger(),
+          disable_linger_, tcp_nodelay_, tcp_congestion_control_));
     } else {
       SerialConnection connection{serial_port_, serial_baud_};
       urg_.reset(

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -432,7 +432,7 @@ bool UrgNode::connect()
         new urg_node::URGCWrapper(
           connection,
           publish_intensity_, publish_multiecho_, this->get_logger(),
-          disable_linger_, tcp_nodelay_, tcp_congestion_control_));
+          disable_linger_);
     } else {
       SerialConnection connection{serial_port_, serial_baud_};
       urg_.reset(

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -432,7 +432,7 @@ bool UrgNode::connect()
         new urg_node::URGCWrapper(
           connection,
           publish_intensity_, publish_multiecho_, this->get_logger(),
-          disable_linger_);
+          disable_linger_));
     } else {
       SerialConnection connection{serial_port_, serial_baud_};
       urg_.reset(

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -73,7 +73,9 @@ UrgNode::UrgNode(const rclcpp::NodeOptions & node_options)
   laser_frame_id_("laser"),
   service_yield_(true),
   status_update_delay_(10.0),
-  reconn_delay_(0.5)
+  reconn_delay_(0.5),
+  tcp_nodelay_(false),
+  tcp_congestion_control_("")
 {
   (void) synchronize_time_;
   initSetup();
@@ -107,6 +109,8 @@ void UrgNode::initSetup()
   cluster_ = this->declare_parameter<int>("cluster", cluster_);
   status_update_delay_ = declare_parameter<double>("status_update_delay", status_update_delay_);
   reconn_delay_ = declare_parameter<double>("reconnect_delay", reconn_delay_);
+  tcp_nodelay_ = declare_parameter<bool>("tcp_nodelay", tcp_nodelay_);
+  tcp_congestion_control_ = declare_parameter<std::string>("tcp_congestion_control", tcp_congestion_control_);
 
   // Set up publishers and diagnostics updaters, we only need one
   if (publish_multiecho_) {

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -74,9 +74,7 @@ UrgNode::UrgNode(const rclcpp::NodeOptions & node_options)
   service_yield_(true),
   status_update_delay_(10.0),
   reconn_delay_(0.5),
-  disable_linger_(false),
-  tcp_nodelay_(false),
-  tcp_congestion_control_("")
+  disable_linger_(false)
 {
   (void) synchronize_time_;
   initSetup();
@@ -111,8 +109,6 @@ void UrgNode::initSetup()
   status_update_delay_ = declare_parameter<double>("status_update_delay", status_update_delay_);
   reconn_delay_ = declare_parameter<double>("reconnect_delay", reconn_delay_);
   disable_linger_ = declare_parameter<bool>("disable_linger", disable_linger_);
-  tcp_nodelay_ = declare_parameter<bool>("tcp_nodelay", tcp_nodelay_);
-  tcp_congestion_control_ = declare_parameter<std::string>("tcp_congestion_control", tcp_congestion_control_);
 
   // Set up publishers and diagnostics updaters, we only need one
   if (publish_multiecho_) {


### PR DESCRIPTION
This PR adds an parameter to disable SO_LINGER timeout on the socket. 

SO_LINGER caused a closed socket to linger for a period to ensure any sent data in the buffer goes out. In this application talking directly to a sensor we don't want/need this behaviour. If we close the socket we want it closed so we can reconnect quickly without any issues.