### PR TITLE
AUTO-912 Add more verbose errors when grabScan fails.

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -233,6 +233,8 @@ bool URGCWrapper::grabScan(sensor_msgs::msg::LaserScan & msg)
     num_beams = urg_get_distance(&urg_, &data_[0], &time_stamp, &system_time_stamp);
   }
   if (num_beams <= 0) {
+    std::string error(urg_error(&urg_));
+    RCLCPP_ERROR(logger_, "Error getting scan: %s", error.c_str());
     return false;
   }
 


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-912)

This PR just add a quick two lines to parse and print the URG error code when a grabScan fails.

Not the final level, I'd like to add later something to bubble up the socket error that will come later.