### PR TITLE
AUTO-912 Fix to properly recover after failed echo scan

### DIFF
--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -260,7 +260,8 @@ bool URGCWrapper::grabScan(sensor_msgs::msg::LaserScan & msg)
   }
   if (num_beams <= 0) {
     std::string error(urg_error(&urg_));
-    RCLCPP_ERROR(logger_, "Error getting scan: %s", error.c_str());
+    RCLCPP_WARN(logger_, "Error grabbing scan: %s streaming data stopped", error.c_str());
+    started_ = false;
     return false;
   }
 

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -548,7 +548,6 @@ void UrgNode::scanThread()
       try {
         std::unique_lock<std::mutex> lock(lidar_mutex_);
         is_started_ = urg_->isStarted();
-        RCLCPP_INFO(this->get_logger(), "is_started: %d", is_started_.load());
         if (publish_multiecho_) {
           sensor_msgs::msg::MultiEchoLaserScan msg;
           if (urg_->grabScan(msg)) {


### PR DESCRIPTION
When reading a scan using the underlying urg_c library the [recieve_data](https://github.com/botsandus/urg_c/blob/53136ab9cf6760317bb322b3b3a6a4a5a661ac94/current/src/urg_sensor.c#L568) function is called. If it throws an error (invalid checksum etc) it calls this function:

```
static void ignore_receive_data_with_qt(urg_t *urg, int timeout)
{
    if ((urg->is_sending == URG_FALSE) && (urg->is_laser_on == URG_FALSE)) {
        return;
    }

    connection_write(&urg->connection, "QT\n", 3);
    urg->is_sending = URG_TRUE;
    urg->is_laser_on = URG_FALSE;
    ignore_receive_data(urg, timeout);
}
```

The QT command does the following:

![image](https://github.com/botsandus/urg_node/assets/2834094/aa8064b0-86c7-4a3c-87a7-23a1bab38aab)

As this all happens in the underlying library the urg_node is not aware that the laser has been switched off so all subsequent calls to grabScan will just fail with the error no response until the error limit is hit and the node reconnects (and restarts the laser)

```
ERROR] [1686579090.278589294] [urg_node]: Error getting scan: checksum error.
[WARN] [1686579090.278654687] [urg_node]: Could not grab single echo scan.
[ERROR] [1686579090.786575012] [urg_node]: Error getting scan: no response.
[WARN] [1686579090.786630406] [urg_node]: Could not grab single echo scan.
[ERROR] [1686579092.343093529] [urg_node]: Error count exceeded limit, reconnecting.
```

In this PR I set started_ to false when the grabScan fails (in urg_c_wrapper) and restart the measurement data once that happens. I've also cleaned up and made this clear in the warning/info messages:

```
[WARN] [1686579589.890574915] [urg_node]: Error grabbing scan: checksum error. streaming data stopped
[INFO] [1686579589.903101895] [urg_node]: Stream stopped due to error, restarting
```

I've also created another [PR](https://github.com/botsandus/auto-robot/pull/180) to update the error limit back to 5, it was originally dropped to 1 because the driver never recovered from a failed scan. Now it does so it's worth not reconnecting too frequently.
