### PR TITLE
AUTO-947 removed connection creation and open from constructor 

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -125,6 +125,8 @@ public:
 
   ~URGCWrapper();
 
+  bool connect();
+
   void start();
 
   void stop();
@@ -261,7 +263,6 @@ private:
   double hardware_clock_;
   long last_hardware_time_stamp_;  // NOLINT
   double hardware_clock_adj_;
-  const double adj_alpha_ = .01;
   uint64_t adj_count_;
 
   /// Logger object used for debug info

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -433,6 +433,7 @@ bool UrgNode::connect()
           connection,
           publish_intensity_, publish_multiecho_, this->get_logger(),
           disable_linger_));
+
     } else {
       SerialConnection connection{serial_port_, serial_baud_};
       urg_.reset(
@@ -441,6 +442,10 @@ bool UrgNode::connect()
           publish_intensity_, publish_multiecho_, this->get_logger()));
     }
 
+    if (!urg_->connect()) {
+      urg_.reset();
+      return false;
+    }
     std::stringstream ss;
     ss << "Connected to";
     if (publish_multiecho_) {
@@ -484,7 +489,7 @@ bool UrgNode::connect()
 
     return true;
   } catch (const std::runtime_error & e) {
-    RCLCPP_ERROR(this->get_logger(), "Error connecting to Hokuyo: %s", e.what());
+    RCLCPP_ERROR(this->get_logger(), "Runtime error connecting to Hokuyo: %s", e.what());
     urg_.reset();
     return false;
   } catch (const std::exception & e) {


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-947)

This PR addresses the issue where the Hokuyo driver continuously fails to open a socket. My contention with this PR is that was caused by the poor error handling in the URGCWrapper constructor. 

The constructor opens the TCP socket and then does some initialisation. If any of the initialisation steps fail it will throw a std::runtime_error.  Leaving the socket open, and because it happens in the constructor the destructor is never called so the socket will never be closed.

I've moved the connection opening into a separate connect() function to avoid throwing the runtime error. 

Side note I also removed the parameter `adj_alpha_` in this PR which seems to do nothing. If it turns out to be the magic variable that holds this house of cards of a driver together please add it back in.
